### PR TITLE
Add testing scaffolds

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,8 +244,8 @@ backend/
 #### Running Tests
 ```bash
 cd backend
-pytest tests/ -v
-pytest tests/ --cov=. --cov-report=html
+pytest -v
+pytest --cov=. --cov-report=html
 ```
 
 ### Frontend Development
@@ -276,7 +276,6 @@ frontend/src/
 ```bash
 cd frontend
 npm test
-npm run test:coverage
 ```
 
 ## 📊 Performance
@@ -400,6 +399,8 @@ We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) f
 3. Make your changes
 4. Add tests for new functionality
 5. Ensure all tests pass
+   - `cd backend && pytest`
+   - `cd .. && npm test`
 6. Submit a pull request
 
 ### Code Style

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  presets: [
+    ['@babel/preset-env', {targets: {node: 'current'}}],
+    ['@babel/preset-react', {runtime: 'automatic'}]
+  ]
+};

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,96 @@
+import sys
+import types
+import os
+import pytest
+
+@pytest.fixture(scope="session", autouse=True)
+def mock_backend_dependencies():
+    # Allow importing backend.* modules
+    backend_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+    if backend_dir not in sys.path:
+        sys.path.insert(0, backend_dir)
+
+    # Create lightweight 'models' package used by backend
+    proj_module = types.ModuleType("models.project")
+    class Project: ...
+    class Clip:
+        def __init__(self, **kwargs):
+            pass
+    class AnalysisRequest: ...
+    class VideoData: ...
+    proj_module.Project = Project
+    proj_module.Clip = Clip
+    proj_module.AnalysisRequest = AnalysisRequest
+    proj_module.VideoData = VideoData
+
+    db_module = types.ModuleType("models.database")
+    class ProjectDB: ...
+    class ClipDB: ...
+    class Setting: ...
+    db_module.Base = object
+    db_module.Project = ProjectDB
+    db_module.Clip = ClipDB
+    db_module.Setting = Setting
+
+    repo_module = types.ModuleType("models.repositories")
+    class ProjectRepository:
+        @staticmethod
+        def get_all_projects(db):
+            return []
+        @staticmethod
+        def get_project_by_id(db, project_id):
+            return None
+        @staticmethod
+        def create_project(db, data):
+            return types.SimpleNamespace(id="1", to_dict=lambda: data)
+        @staticmethod
+        def delete_project(db, project_id):
+            return True
+        @staticmethod
+        def update_project(db, project_id, data):
+            return types.SimpleNamespace(id=project_id, to_dict=lambda: data)
+    class ClipRepository:
+        @staticmethod
+        def get_clip_by_id(db, clip_id):
+            return None
+        @staticmethod
+        def update_clip(db, clip_id, clip_data):
+            return types.SimpleNamespace(to_dict=lambda: clip_data)
+        @staticmethod
+        def delete_clip(db, clip_id):
+            return True
+        @staticmethod
+        def get_clips_by_project(db, project_id):
+            return []
+        @staticmethod
+        def create_clip(db, clip_dict):
+            return types.SimpleNamespace(id="c1", to_dict=lambda: clip_dict)
+    class SettingsRepository:
+        @staticmethod
+        def create_or_update_setting(db, category, key, value):
+            return None
+        @staticmethod
+        def get_settings_by_category(db, category):
+            return []
+        @staticmethod
+        def get_setting(db, category, key):
+            return None
+    repo_module.ProjectRepository = ProjectRepository
+    repo_module.ClipRepository = ClipRepository
+    repo_module.SettingsRepository = SettingsRepository
+
+    models_pkg = types.ModuleType("models")
+    models_pkg.project = proj_module
+    models_pkg.database = db_module
+    models_pkg.repositories = repo_module
+
+    sys.modules.setdefault("models", models_pkg)
+    sys.modules.setdefault("models.project", proj_module)
+    sys.modules.setdefault("models.database", db_module)
+    sys.modules.setdefault("models.repositories", repo_module)
+
+    yield
+
+    # Cleanup
+    for name in ["models", "models.project", "models.database", "models.repositories"]:
+        sys.modules.pop(name, None)

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -1,0 +1,15 @@
+from fastapi.testclient import TestClient
+
+
+def get_client():
+    import backend.main as main
+    return TestClient(main.app)
+
+
+def test_get_providers():
+    client = get_client()
+    response = client.get("/api/providers")
+    assert response.status_code == 200
+    data = response.json()
+    assert "providers" in data
+    assert any(p["id"] == "openai" for p in data["providers"])

--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -1,0 +1,20 @@
+from pydantic import ValidationError
+import pytest
+
+
+def get_model():
+    import backend.main as main
+    return main.ProjectCreateRequest
+
+
+def test_project_create_request_required_fields():
+    ProjectCreateRequest = get_model()
+    req = ProjectCreateRequest(name="Demo", type="upload")
+    assert req.name == "Demo"
+    assert req.type == "upload"
+
+
+def test_project_create_request_missing_name():
+    ProjectCreateRequest = get_model()
+    with pytest.raises(ValidationError):
+        ProjectCreateRequest(type="upload")

--- a/frontend/babel.config.js
+++ b/frontend/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  presets: [
+    ['@babel/preset-env', {targets: {node: 'current'}}],
+    ['@babel/preset-react', {runtime: 'automatic'}]
+  ]
+};

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/tests/setupTests.js'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1'
+  },
+  transform: {
+    '^.+\\.[jt]sx?$': 'babel-jest'
+  }
+};

--- a/frontend/tests/errorBoundary.test.jsx
+++ b/frontend/tests/errorBoundary.test.jsx
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import ErrorBoundary from '../../src/components/Common/ErrorBoundary.jsx';
+
+function Problem() {
+  throw new Error('boom');
+}
+
+test('shows fallback UI when child throws', () => {
+  render(
+    <ErrorBoundary>
+      <Problem />
+    </ErrorBoundary>
+  );
+  expect(screen.getByText(/Something went wrong/i)).toBeInTheDocument();
+});

--- a/frontend/tests/setupTests.js
+++ b/frontend/tests/setupTests.js
@@ -1,0 +1,1 @@
+require('@testing-library/jest-dom');

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "preview": "vite preview",
     "backend": "cd backend && python -m uvicorn main:app --reload --port 8000",
-    "start": "concurrently \"npm run backend\" \"npm run dev\""
+    "start": "concurrently \"npm run backend\" \"npm run dev\"",
+    "test": "jest --config frontend/jest.config.js"
   },
   "dependencies": {
     "@ffmpeg/ffmpeg": "^0.12.7",
@@ -30,11 +31,18 @@
     "zustand": "^4.4.1"
   },
   "devDependencies": {
+    "@babel/preset-env": "^7.24.5",
+    "@babel/preset-react": "^7.22.15",
+    "@testing-library/jest-dom": "^6.2.0",
+    "@testing-library/react": "^14.2.1",
     "@types/react": "^18.2.15",
     "@types/react-dom": "^18.2.7",
     "@vitejs/plugin-react": "^4.0.3",
     "autoprefixer": "^10.4.14",
+    "babel-jest": "^29.7.0",
     "concurrently": "^8.2.0",
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^30.0.0-beta.3",
     "postcss": "^8.4.27",
     "tailwindcss": "^3.3.3",
     "vite": "^4.4.5"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+addopts = -ra
+pythonpath = .


### PR DESCRIPTION
## Summary
- set up backend tests with pytest and dummy model fixtures
- create simple API and model tests
- add React testing setup with Jest and React Testing Library
- add example frontend test for ErrorBoundary component
- document running tests in README

## Testing
- `pytest backend/tests -q`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68415739fe488327a001004792c20201